### PR TITLE
[020] Umami Analytics

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,4 +1,4 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
     <head>
         <meta charset="UTF-8" />
@@ -10,4 +10,10 @@
         <div id="root"></div>
         <script type="module" src="/src/main.jsx"></script>
     </body>
+
+    <script
+        defer
+        src="https://cloud.umami.is/script.js"
+        data-website-id="%VITE_UMAMI_WEBSITE_ID%"
+    ></script>
 </html>

--- a/src/analytics/umami.ts
+++ b/src/analytics/umami.ts
@@ -1,0 +1,37 @@
+export type ResumeLocation = "home" | "experience";
+export type OutboundTarget = "github" | "linkedin";
+
+function track(event: string, data?: Record<string, unknown>) {
+    if (
+        typeof window != "undefined" &&
+        typeof window.umami?.track == "function"
+    ) {
+        window.umami.track(event, data);
+    }
+}
+
+export function trackResumeDownloadClick(location: ResumeLocation) {
+    track("download_resume_click", { location });
+}
+
+export function trackOutboundClick(outboundTarget: OutboundTarget) {
+    track("outbound_click", { outboundTarget });
+}
+
+export function trackLanguageChange(languageCode: string) {
+    track("language_change", { languageCode });
+}
+
+export function trackThemeChange(theme: string) {
+    track("theme_change", { theme });
+}
+
+export function trackProjectSourCodeClick(project: string) {
+    track("project_source_code_click", {
+        project,
+    });
+}
+
+export function trackSendContactClick() {
+    track("send_contact_click");
+}

--- a/src/components/DownloadResumeButton.tsx
+++ b/src/components/DownloadResumeButton.tsx
@@ -1,12 +1,20 @@
 import { useTranslation } from "react-i18next";
 import { SPRITE_URL } from "../constants/paths";
-import { LANGUAGES, useSettings } from "../contexts/SettingsContext";
+import { useSettings } from "../contexts/SettingsContext";
+import { ResumeLocation, trackResumeDownloadClick } from "../analytics/umami";
 
-export default function DownloadResumeButton() {
+type DownloadResumeButtonProps = {
+    location: ResumeLocation;
+};
+
+export default function DownloadResumeButton({
+    location,
+}: DownloadResumeButtonProps) {
     const { t } = useTranslation();
     const { language } = useSettings();
 
     function handleClick() {
+        trackResumeDownloadClick(location);
         const resumeUrl = `https://icdominguez.ddns.net/dev/api/cv?lang=${language.code}`;
         window.open(resumeUrl, "_blank");
     }

--- a/src/features/contact/Contact.tsx
+++ b/src/features/contact/Contact.tsx
@@ -3,6 +3,7 @@ import { SPRITE_URL } from "../../constants/paths";
 import { useTranslation, Trans } from "react-i18next";
 import { SectionTitle } from "../../components/SectionTitle";
 import { sendContact } from "../../services/contact.service";
+import { trackSendContactClick } from "../../analytics/umami";
 
 type Banner = { type: "success" | "error"; text: string } | null;
 
@@ -40,6 +41,7 @@ export default function Contact() {
     };
 
     const handleSubmit = async (e: React.FormEvent) => {
+        trackSendContactClick();
         setIsSending(true);
         e.preventDefault();
 

--- a/src/features/experience/Experience.tsx
+++ b/src/features/experience/Experience.tsx
@@ -14,7 +14,7 @@ export default function Experience() {
 
             <Timeline />
 
-            <DownloadResumeButton />
+            <DownloadResumeButton location="experience" />
         </section>
     );
 }

--- a/src/features/home/Home.tsx
+++ b/src/features/home/Home.tsx
@@ -4,15 +4,18 @@ import TerminalParallax3DEffect from "./TerminalParallax3DEffect";
 import { SPRITE_URL } from "../../constants/paths";
 import SocialButton from "../../components/SocialButton";
 import DownloadResumeButton from "../../components/DownloadResumeButton";
+import { trackOutboundClick } from "../../analytics/umami";
 
 export default function Home() {
     const { t } = useTranslation();
 
     const handleGithubClick = () => {
+        trackOutboundClick("github");
         window.open("https://github.com/icdominguez", "_blank");
     };
 
     const handleLinkedinClick = () => {
+        trackOutboundClick("linkedin");
         window.open(
             "https://linkedin.com/in/ismael-cordon-dominguez/",
             "_blank",
@@ -43,7 +46,7 @@ export default function Home() {
                         </p>
 
                         <div className="flex flex-row gap-4 items-center">
-                            <DownloadResumeButton />
+                            <DownloadResumeButton location="home" />
 
                             <SocialButton
                                 icon={`${SPRITE_URL}#github-icon`}

--- a/src/features/projects/ProjectItem.tsx
+++ b/src/features/projects/ProjectItem.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 import { SPRITE_URL } from "../../constants/paths";
 import { Project } from "./types/Project";
+import { trackProjectSourCodeClick } from "../../analytics/umami";
 
 export default function ProjectItem({ project }: { project: Project }) {
     const { t } = useTranslation();
@@ -10,6 +11,7 @@ export default function ProjectItem({ project }: { project: Project }) {
             <div className="relative h-90 overflow-hidden">
                 <div className="absolute inset-0 z-10 flex items-end justify-end p-4">
                     <a
+                        onClick={() => trackProjectSourCodeClick(project.title)}
                         href={project.projectUrl}
                         className="pointer-events-auto flex items-center gap-2 bg-white/90 dark:bg-slate-800/90 backdrop-blur-md border border-slate-200 dark:border-slate-700 dark:hover:bg-slate-700 hover:border-blue-500 rounded-xl px-4 py-2 text-sm font-semibold [@media(hover:hover)]:opacity-0 [@media(hover:hover)]:group-hover:opacity-100 hover:bg-white transition-all duration-300"
                         target="_blank"

--- a/src/types/umami.d.ts
+++ b/src/types/umami.d.ts
@@ -1,0 +1,10 @@
+export {};
+
+declare global {
+    interface Window {
+        umami?: {
+            track: (event: string, data?: Record<string, any>) => void;
+            trackView: (url?: string) => void;
+        };
+    }
+}


### PR DESCRIPTION
This commit introduces Umami Analytics to the project in order to be able to track events on the amount of visits:

Analytics added:

- ``download_resume_click``:  Download CV with the param ``location``to know from where it was called: home or experience.
- `outbound_click`: To track which social media the users goes. ``outboundTarget`` param that can be github or linkedin
- `language_change`: To track how many times the users change the website language. ``language``param.
 - `theme_change`: To track how many times the users change the website theme. ``theme`` param
 - `project_source_code_click`: To get stadistics about which is the most viewed project. Param ``project``that shows the name.
 - `send_contact_click`: Just to track how many clicks are on the contact form